### PR TITLE
scylla bg quick-fix: remove mention of rainbow

### DIFF
--- a/_includes/testing_pcb_dactyl.md
+++ b/_includes/testing_pcb_dactyl.md
@@ -1,0 +1,36 @@
+# Testing the PCBs
+
+Now is a great time to function test the assembled PCBs, as any troubleshooting steps you might need to complete will be much easier to do while the plates are still outside of the case.
+
+{: .note }
+The TRRS connection will not work yet, as only ony one leg of the jack is connected. You can test this part later.
+
+**For the following step, please prepare** a pair of tweezers that are conductive. If you don't have any, you can also use a piece of wire, or a single switch.
+
+## Testing the LEDs
+
+If you have installed per-key LEDs, let's start with testing those.
+If you don't have any per-key RGB installed, you can skip to the next section.
+
+- connect one half to your PC via USB, and observe the LEDs:
+- do they all light up? 
+- can you see all LEDs show bright red?
+
+Does everything look fine? Great, go ahead with testing the switches. 
+
+If not, reflowing the pads of the LEDs not working should do the trick. Please see [Troubleshooting]({{site.baseurl}}/help/troubleshooting.html#one-or-more-leds-dont-work) for details.
+
+## Testing the switches
+
+To test the switches, we are going to use the VIA interface. All Bastard Keyboards come pre-flashed with VIA, so you don't have to flash anything.
+
+Open [VIA](https://usevia.app/) - please note this only works on chromium-based browsers like chromium, edge, chrome.
+
+![](../assets/pics/guides/generic/7.jpg)
+
+After connecting to your device, switch to the key tester page using the stethoscope pictogram, then activate the "Test Matrix" option. Now, you can connect each pair of switch pads in turn, using your tweezers, a wire, or a switch inclined enough.
+
+
+![](../assets/pics/guides/generic/8.jpg)
+
+Did all the keys light up in VIA? Great, proceed to case installation! Not quite perfect yet? Don't worry, proceed to the [Troubleshooting]({{site.baseurl}}/help/troubleshooting.html) section!

--- a/bg_scylla/10install_the_switches.md
+++ b/bg_scylla/10install_the_switches.md
@@ -10,7 +10,42 @@ parent: Build guide - Scylla
 1. TOC
 {:toc}
 
-{% include testing_pcb.md %}
+# Testing the PCBs
+
+Now is a great time to function test the assembled PCBs, as any troubleshooting steps you might need to complete will be much easier to do while the plates are still outside of the case.
+
+{: .note }
+The TRRS connection will not work yet, as only ony one leg of the jack is connected. You can test this part later.
+
+**For the following step, please prepare** a pair of tweezers that are conductive. If you don't have any, you can also use a piece of wire, or a single switch.
+
+## Testing the LEDs
+
+If you have installed per-key LEDs, let's start with testing those.
+If you don't have any per-key RGB installed, you can skip to the next section.
+
+- connect one half to your PC via USB, and observe the LEDs:
+- do they all light up? 
+- can you see all LEDs show bright red?
+
+Does everything look fine? Great, go ahead with testing the switches. 
+
+If not, reflowing the pads of the LEDs not working should do the trick. Please see [Troubleshooting]({{site.baseurl}}/help/troubleshooting.html#one-or-more-leds-dont-work) for details.
+
+## Testing the switches
+
+To test the switches, we are going to use the VIA interface. All Bastard Keyboards come pre-flashed with VIA, so you don't have to flash anything.
+
+Open [VIA](https://usevia.app/) - please note this only works on chromium-based browsers like chromium, edge, chrome.
+
+![](../assets/pics/guides/generic/7.jpg)
+
+After connecting to your device, switch to the key tester page using the stethoscope pictogram, then activate the "Test Matrix" option. Now, you can connect each pair of switch pads in turn, using your tweezers, a wire, or a switch inclined enough.
+
+
+![](../assets/pics/guides/generic/8.jpg)
+
+Did all the keys light up in VIA? Great, proceed to case installation! Not quite perfect yet? Don't worry, proceed to the [Troubleshooting]({{site.baseurl}}/help/troubleshooting.html) section!
 
 # Introduction
 

--- a/bg_scylla/10install_the_switches.md
+++ b/bg_scylla/10install_the_switches.md
@@ -10,42 +10,7 @@ parent: Build guide - Scylla
 1. TOC
 {:toc}
 
-# Testing the PCBs
-
-Now is a great time to function test the assembled PCBs, as any troubleshooting steps you might need to complete will be much easier to do while the plates are still outside of the case.
-
-{: .note }
-The TRRS connection will not work yet, as only ony one leg of the jack is connected. You can test this part later.
-
-**For the following step, please prepare** a pair of tweezers that are conductive. If you don't have any, you can also use a piece of wire, or a single switch.
-
-## Testing the LEDs
-
-If you have installed per-key LEDs, let's start with testing those.
-If you don't have any per-key RGB installed, you can skip to the next section.
-
-- connect one half to your PC via USB, and observe the LEDs:
-- do they all light up? 
-- can you see all LEDs show bright red?
-
-Does everything look fine? Great, go ahead with testing the switches. 
-
-If not, reflowing the pads of the LEDs not working should do the trick. Please see [Troubleshooting]({{site.baseurl}}/help/troubleshooting.html#one-or-more-leds-dont-work) for details.
-
-## Testing the switches
-
-To test the switches, we are going to use the VIA interface. All Bastard Keyboards come pre-flashed with VIA, so you don't have to flash anything.
-
-Open [VIA](https://usevia.app/) - please note this only works on chromium-based browsers like chromium, edge, chrome.
-
-![](../assets/pics/guides/generic/7.jpg)
-
-After connecting to your device, switch to the key tester page using the stethoscope pictogram, then activate the "Test Matrix" option. Now, you can connect each pair of switch pads in turn, using your tweezers, a wire, or a switch inclined enough.
-
-
-![](../assets/pics/guides/generic/8.jpg)
-
-Did all the keys light up in VIA? Great, proceed to case installation! Not quite perfect yet? Don't worry, proceed to the [Troubleshooting]({{site.baseurl}}/help/troubleshooting.html) section!
+{% include testing_pcb_dactyl.md %}
 
 # Introduction
 

--- a/bg_skeletyl/10install_the_switches.md
+++ b/bg_skeletyl/10install_the_switches.md
@@ -10,7 +10,7 @@ parent: Build guide - Skeletyl
 1. TOC
 {:toc}
 
-{% include testing_pcb.md %}
+{% include testing_pcb_dactyl.md %}
 
 # Introduction
 


### PR DESCRIPTION
The Scylla has no rgb effects beyond the default enabled, but the guide's testing section asks the user to look for a rainbow.

This quick-fix measure duplicates the testing include into the Scylla build guide and changes the wording to refer to the red effect.

Preview: https://finrod09.github.io/bastardkb.github.io/bg_scylla/10install_the_switches.html