### PR TITLE
direct links to releases to the bkb userspace instead

### DIFF
--- a/fw/compile-firmware.md
+++ b/fw/compile-firmware.md
@@ -23,7 +23,7 @@ This page details how to build your own firmware.
 Building from source is useful to people who want to customize their keyboard and keymaps beyond what Via offers. 
 You will have to modify the keymap `C` code, and from there compile your firmware either using Github actions or the local command line.
 
-If that seems too complicated, you can also use one of the [release firmware](https://github.com/Bastardkb/bastardkb-qmk/releases/latest) builds.
+If that seems too complicated, you can also use one of the [release firmware](https://github.com/Bastardkb/qmk_userspace/releases/latest) builds.
 
 # Pre-requisites
 

--- a/fw/default-keymaps.md
+++ b/fw/default-keymaps.md
@@ -13,7 +13,7 @@ parent: Firmware
 This page contains reference pictures for all the default keymaps flashed onto the Bastard Keyboards.
 
 Releases are available here:
-https://github.com/Bastardkb/bastardkb-qmk/releases
+https://github.com/Bastardkb/qmk_userspace/releases
 
 For more information on the features from the Charybdis keymaps, see the [charybdis features][chary] page.
 

--- a/fw/flashing.md
+++ b/fw/flashing.md
@@ -133,6 +133,6 @@ If you use the `QK_BOOT` method, please note that your layout may now be mirrore
 
 ---- 
 [build]: {{site.baseurl}}/fw/compile-firmware.html
-[releases]: https://github.com/Bastardkb/bastardkb-qmk/releases
+[releases]: https://github.com/Bastardkb/qmk_userspace/releases
 [keymaps]: {{site.baseurl}}/fw/default-keymaps.html
 [splitkb-whentoflash]: https://docs.splitkb.com/hc/en-us/articles/360011949679-When-do-I-need-to-flash-my-microcontroller

--- a/help/troubleshooting.md
+++ b/help/troubleshooting.md
@@ -82,7 +82,7 @@ Received invalid protocol version from device
 
 Outlined below are some steps, in order of complexity:
 - make sure you use a chromium-based browser like edge, google chrome
-- flash the [latest firmware version](https://github.com/Bastardkb/bastardkb-qmk/releases/latest)
+- flash the [latest firmware version](https://github.com/Bastardkb/qmk_userspace/releases/latest)
 
 ### Custom udev rules
 

--- a/hw/rp2040-community.md
+++ b/hw/rp2040-community.md
@@ -36,7 +36,7 @@ Controller | Pin-compatible | Flash size | Vbus detection | Notes
 
 # Firmware compatibility
 
-All controllers above marked as pin-compatible, and using the QMK default `W25Q080` second-stage bootloader, should be compatible out-of-the-box with the [Bastard Keyboard firmwares](https://github.com/bastardkb/bastardkb-qmk/releases) targeting the Splinky v3, _ie._ `splinky_3` firmwares.
+All controllers above marked as pin-compatible, and using the QMK default `W25Q080` second-stage bootloader, should be compatible out-of-the-box with the [Bastard Keyboard firmwares](https://github.com/Bastardkb/qmk_userspace/releases).
 
 ## Bootloader
 


### PR DESCRIPTION
This change points all links that went to the `bastardbk-qmk` releases page to `bastardkb:qmk/userspace` releases page instead.

I've also removed reference to the `splinky` firmwares from the Controllers page, as splinky is now the only firmware and no longer labelled as such.