### PR TITLE
Clarify hotswap and switches for the Dilemma.

### DIFF
--- a/bg_dilemma/v1.md
+++ b/bg_dilemma/v1.md
@@ -102,7 +102,10 @@ This step is optional, but highly recommended.
 
 # Soldering the switches
 
-Solder in your switches of preference.
+Solder in your switches of preference. The dilemma is compatible with MX and Choc V1 switches.
+
+{: .warning }
+Choc V2 switches are not compatible!
 
 # Customize your firmware
 

--- a/bg_dilemma/v1.md
+++ b/bg_dilemma/v1.md
@@ -102,10 +102,10 @@ This step is optional, but highly recommended.
 
 # Soldering the switches
 
-Solder in your switches of preference. The Dilemma is compatible with MX and Choc V1 switches.
+Solder in your switches of preference. The Dilemma is compatible with MX (normal profile) and Choc V1 switches.
 
 {: .warning }
-Choc V2 switches are not compatible!
+Choc V2 and low-profile MX switches are not compatible!
 
 # Customize your firmware
 

--- a/bg_dilemma/v1.md
+++ b/bg_dilemma/v1.md
@@ -102,7 +102,7 @@ This step is optional, but highly recommended.
 
 # Soldering the switches
 
-Solder in your switches of preference. The dilemma is compatible with MX and Choc V1 switches.
+Solder in your switches of preference. The Dilemma is compatible with MX and Choc V1 switches.
 
 {: .warning }
 Choc V2 switches are not compatible!

--- a/bg_dilemma/v2.md
+++ b/bg_dilemma/v2.md
@@ -114,7 +114,7 @@ This step is optional, but highly recommended.
 
 # Soldering the switches
 
-Solder in your switches of preference. The dilemma is compatible with MX and Choc V1 switches.
+Solder in your switches of preference. The Dilemma is compatible with MX and Choc V1 switches.
 
 {: .warning }
 Choc V2 switches are not compatible!

--- a/bg_dilemma/v2.md
+++ b/bg_dilemma/v2.md
@@ -114,7 +114,10 @@ This step is optional, but highly recommended.
 
 # Soldering the switches
 
-Solder in your switches of preference.
+Solder in your switches of preference. The dilemma is compatible with MX and Choc V1 switches.
+
+{: .warning }
+Choc V2 switches are not compatible!
 
 # Customize your firmware
 

--- a/bg_dilemma/v2.md
+++ b/bg_dilemma/v2.md
@@ -114,10 +114,10 @@ This step is optional, but highly recommended.
 
 # Soldering the switches
 
-Solder in your switches of preference. The Dilemma is compatible with MX and Choc V1 switches.
+Solder in your switches of preference. The Dilemma is compatible with MX (normal profile) and Choc V1 switches.
 
 {: .warning }
-Choc V2 switches are not compatible!
+Choc V2 and low-profile MX switches are not compatible!
 
 # Customize your firmware
 

--- a/faq.md
+++ b/faq.md
@@ -21,7 +21,7 @@ You can read more on how to customize your keyboard [on the How to use and custo
 {: .question }
 Is it possible to build a hotswap Bastard Keyboard?
 
-It's not possible to use MX sockets, because they need a specific footprint on the PCB which is not present. It is in theory possible to use Millmax sockets, though not recommended.
+It is not possible to use MX or Choc sockets, because they need a specific footprint on the PCB which is not present. It is in theory possible to use Millmax sockets, though not recommended.
 
 When installing the PCBs, you bend them to fit it to the curvature so the whole thing is continuously under tension, pulling away from the switch plate, only held in place by the switch pins and solder joints.
 

--- a/faq.md
+++ b/faq.md
@@ -21,7 +21,6 @@ You can read more on how to customize your keyboard [on the How to use and custo
 {: .question }
 Is it possible to build a hotswap Bastard Keyboard?
 
-**On the 3d keyboards (Scylla, Charybdis...):**
 It's not possible to use MX sockets, because they need a specific footprint on the PCB which is not present. It is in theory possible to use Millmax sockets, though not recommended.
 
 When installing the PCBs, you bend them to fit it to the curvature so the whole thing is continuously under tension, pulling away from the switch plate, only held in place by the switch pins and solder joints.


### PR DESCRIPTION
I started my first Dilemma build, and was a bit confused by some things in the docs.

First, the docs specifically call out 3D keyboards not being compatible with hotswap,
but say nothing about the Dilemma. After asking on the Discord, I found out that the
Dilemma also does not support hotswap, which I think covers all keyboards from BastardKB,
so I don't think the "3d keyboards" qualification is necessary.

Second, I couldn't find any information about what kind of switches are supported on either
the docs or the product page. It would be great to add this to the product page as well,
where it says "Keycaps, switches and cables not included.".

I got the information on compatibility from @burkfers on Discord.
