### PR TITLE
fix: update left side thumb cluster diode guide

### DIFF
--- a/bg_scylla/05diodes.md
+++ b/bg_scylla/05diodes.md
@@ -83,7 +83,7 @@ Do the same for the 12 diodes.
 
 ## Left side - thumb cluster - placing the PCB
 
--   Place the plate PCB on your working surface, and make sure the "RIGHT" label is visible
+-   Place the plate PCB on your working surface, and make sure the "LEFT" label is visible
 -   Use the picture below for reference.
 
 ![](../assets/pics/guides/charybdis/21.jpg)


### PR DESCRIPTION
This tripped me up when following the guide to build a Scylla. I'm pretty sure it's supposed to say "LEFT". Please double check though. I guess this was copy pasted from the Charybdis guide in which you build the right side first.