### PR TITLE
fix: update left side thumb cluster diode guide

### DIFF
--- a/bg_scylla/05diodes.md
+++ b/bg_scylla/05diodes.md
@@ -90,7 +90,7 @@ Do the same for the 12 diodes.
 
 ## Left side - thumb cluster - installing the diodes
 
-On the thumb cluster PCB, we need to install a total of 3 diodes. They go on the footprints with 2 pads (see pictures below).
+On the thumb cluster PCB, we need to install a total of 5 diodes. They go on the footprints with 2 pads (see pictures below).
 
 {: .warning }
 These diodes need to be installed in a specific way, or they will not work! **Read the following carefully.**


### PR DESCRIPTION
This tripped me up when following the guide to build a Scylla. I'm pretty sure it's supposed to say "5". Please double check though. I guess this was copy pasted from the Charybdis guide in which there is less diodes on the "ball side" thumb PCB.